### PR TITLE
refactor: move from alert to node-notifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
-        "alert": "^5.1.1",
         "cfonts": "^3.1.1",
         "colorette": "^2.0.19",
+        "node-notifier": "^10.0.1",
         "terminal-kit": "^3.0.0",
         "yargs": "^17.5.1"
       },
@@ -22,6 +22,7 @@
         "@tsconfig/recommended": "^1.0.1",
         "@types/jest": "^29.1.2",
         "@types/node": "^18.7.23",
+        "@types/node-notifier": "^8.0.3",
         "@types/terminal-kit": "^2.5.0",
         "@types/yargs": "^17.0.13",
         "jest": "^29.2.0",
@@ -1164,6 +1165,15 @@
       "integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
       "dev": true
     },
+    "node_modules/@types/node-notifier": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node-notifier/-/node-notifier-8.0.3.tgz",
+      "integrity": "sha512-hbAykVDD1DKj5iiV9ecAKX1GuYSKtFIpBJxaWCrXHW3hzZs9AHu8dGOLMsjYT2HZyCeJJSsZgQPAEu9RmCKgnQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/prettier": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
@@ -1219,24 +1229,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/alert": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/alert/-/alert-5.1.1.tgz",
-      "integrity": "sha512-ewGBn8yvZGGEIEY+P7syG4GYPlFtZMEhgnt0Xo5ldJNGPA6PNw9x3/Ng3tKHAcySbWn8ymaA6YMoVkVn0HwzCQ==",
-      "dependencies": {
-        "is-program-installed": "2.3.4"
-      },
-      "bin": {
-        "alert": "cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "funding": {
-        "type": "ko-fi",
-        "url": "https://ko-fi.com/zacanger"
       }
     },
     "node_modules/ansi-escapes": {
@@ -1987,6 +1979,11 @@
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
+    "node_modules/growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw=="
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -2129,6 +2126,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2168,18 +2179,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-program-installed": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/is-program-installed/-/is-program-installed-2.3.4.tgz",
-      "integrity": "sha512-b4e65BxUsiLkoFSOu8RAca7Rz7rPvnbw0u0lS431BFyI37C4lM6F+OjQ5DNODMakjKfcoOY9aeaPqXgFoezhsg==",
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "funding": {
-        "type": "ko-fi",
-        "url": "https://ko-fi.com/zacanger"
-      }
-    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -2192,11 +2191,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -2950,7 +2959,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3079,6 +3087,33 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
+    },
+    "node_modules/node-notifier": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
+      "integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
+      "dependencies": {
+        "growly": "^1.3.0",
+        "is-wsl": "^2.2.0",
+        "semver": "^7.3.5",
+        "shellwords": "^0.1.1",
+        "uuid": "^8.3.2",
+        "which": "^2.0.2"
+      }
+    },
+    "node_modules/node-notifier/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.6",
@@ -3445,6 +3480,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -3844,6 +3884,14 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -3887,7 +3935,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -3959,8 +4006,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "17.5.1",
@@ -4929,6 +4975,15 @@
       "integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
       "dev": true
     },
+    "@types/node-notifier": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node-notifier/-/node-notifier-8.0.3.tgz",
+      "integrity": "sha512-hbAykVDD1DKj5iiV9ecAKX1GuYSKtFIpBJxaWCrXHW3hzZs9AHu8dGOLMsjYT2HZyCeJJSsZgQPAEu9RmCKgnQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/prettier": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
@@ -4976,14 +5031,6 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
-    },
-    "alert": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/alert/-/alert-5.1.1.tgz",
-      "integrity": "sha512-ewGBn8yvZGGEIEY+P7syG4GYPlFtZMEhgnt0Xo5ldJNGPA6PNw9x3/Ng3tKHAcySbWn8ymaA6YMoVkVn0HwzCQ==",
-      "requires": {
-        "is-program-installed": "2.3.4"
-      }
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -5539,6 +5586,11 @@
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
+    "growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw=="
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -5648,6 +5700,11 @@
         "kind-of": "^6.0.2"
       }
     },
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -5677,22 +5734,24 @@
         }
       }
     },
-    "is-program-installed": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/is-program-installed/-/is-program-installed-2.3.4.tgz",
-      "integrity": "sha512-b4e65BxUsiLkoFSOu8RAca7Rz7rPvnbw0u0lS431BFyI37C4lM6F+OjQ5DNODMakjKfcoOY9aeaPqXgFoezhsg=="
-    },
     "is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
     },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -6271,7 +6330,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -6376,6 +6434,29 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
+    },
+    "node-notifier": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
+      "integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
+      "requires": {
+        "growly": "^1.3.0",
+        "is-wsl": "^2.2.0",
+        "semver": "^7.3.5",
+        "shellwords": "^0.1.1",
+        "uuid": "^8.3.2",
+        "which": "^2.0.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
     },
     "node-releases": {
       "version": "2.0.6",
@@ -6636,6 +6717,11 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -6891,6 +6977,11 @@
         "picocolors": "^1.0.0"
       }
     },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -6933,7 +7024,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -6981,8 +7071,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "17.5.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@tsconfig/recommended": "^1.0.1",
     "@types/jest": "^29.1.2",
     "@types/node": "^18.7.23",
+    "@types/node-notifier": "^8.0.3",
     "@types/terminal-kit": "^2.5.0",
     "@types/yargs": "^17.0.13",
     "jest": "^29.2.0",
@@ -40,9 +41,9 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "alert": "^5.1.1",
     "cfonts": "^3.1.1",
     "colorette": "^2.0.19",
+    "node-notifier": "^10.0.1",
     "terminal-kit": "^3.0.0",
     "yargs": "^17.5.1"
   }

--- a/src/asuka.ts
+++ b/src/asuka.ts
@@ -1,6 +1,6 @@
 import { yellow, bgRedBright, bold, red, bgYellow } from "colorette";
 import terminalKitPackage from "terminal-kit";
-import alert from "alert";
+import { notify } from "node-notifier";
 import { example, rl } from ".";
 import path from "path";
 
@@ -64,6 +64,6 @@ export const asuka = () => {
     process.exit();
   }, 10000);
   theBeast;
-  alert("🚨TIME🚨");
+  notify("🚨TIME🚨");
   clearAll;
 };

--- a/src/dss.ts
+++ b/src/dss.ts
@@ -1,6 +1,6 @@
 import { yellow, bgBlack, bold, red } from "colorette";
 import terminalKitPackage from "terminal-kit";
-import alert from "alert";
+import { notify } from "node-notifier";
 import { example, rl } from ".";
 import path from "path";
 
@@ -56,6 +56,6 @@ export const dss = () => {
     process.exit();
   }, 10000);
   theChoker;
-  alert("🚨TIME🚨");
+  notify("🚨TIME🚨");
   clearAll;
 };

--- a/src/endings.ts
+++ b/src/endings.ts
@@ -9,7 +9,7 @@ import { dss } from "./dss";
 import { gendo } from "./gendo";
 import { nerv } from "./nerv";
 import { seele } from "./seele";
-import alert from "alert";
+import { notify } from "node-notifier";
 import { kaworu } from "./kaworu";
 import { asuka } from "./asuka";
 
@@ -18,7 +18,7 @@ export const endingAnimationCall = (argv: Argv) => {
     function empty() {
         rl.write("\u001B[?25h");
         console.clear();
-        alert("🚨TIME🚨");
+        notify("🚨TIME🚨");
         process.exit();
     }
 

--- a/src/gendo.ts
+++ b/src/gendo.ts
@@ -1,6 +1,6 @@
 import { yellow, bgBlack, bold, red, bgRed, black } from "colorette";
 import terminalKitPackage from "terminal-kit";
-import alert from "alert";
+import { notify } from "node-notifier";
 import { example, rl } from ".";
 import path from "path";
 
@@ -64,6 +64,6 @@ export const gendo = () => {
     process.exit();
   }, 10000);
   theFather;
-  alert("🚨TIME🚨");
+  notify("🚨TIME🚨");
   clearAll;
 };

--- a/src/kaworu.ts
+++ b/src/kaworu.ts
@@ -1,6 +1,6 @@
 import { yellow, bold, cyan, magenta, bgBlack, bgBlueBright } from "colorette";
 import terminalKitPackage from "terminal-kit";
-import alert from "alert";
+import { notify } from "node-notifier";
 import { example, rl } from ".";
 import path from "path";
 
@@ -64,6 +64,6 @@ export const kaworu = () => {
     process.exit();
   }, 10000);
   theBeast;
-  alert("🚨TIME🚨");
+  notify("🚨TIME🚨");
   clearAll;
 };

--- a/src/mari-the-beast.ts
+++ b/src/mari-the-beast.ts
@@ -1,6 +1,6 @@
 import { green, yellow, bgRedBright, bold } from "colorette";
 import terminalKitPackage from "terminal-kit";
-import alert from "alert";
+import { notify } from "node-notifier";
 import { example, rl } from ".";
 import path from "path";
 
@@ -62,6 +62,6 @@ export const mari = () => {
     process.exit();
   }, 10000);
   theBeast;
-  alert("🚨TIME🚨");
+  notify("🚨TIME🚨");
   clearAll;
 };

--- a/src/nerv.ts
+++ b/src/nerv.ts
@@ -1,6 +1,6 @@
 import { yellow, bgBlack, bold, redBright } from "colorette";
 import terminalKitPackage from "terminal-kit";
-import alert from "alert";
+import { notify } from "node-notifier";
 import { example, rl } from ".";
 import path from "path";
 
@@ -64,6 +64,6 @@ export const nerv = () => {
     process.exit();
   }, 10000);
   theNerv;
-  alert("🚨TIME🚨");
+  notify("🚨TIME🚨");
   clearAll;
 };

--- a/src/pen.ts
+++ b/src/pen.ts
@@ -1,6 +1,6 @@
 import { white, yellow, bgBlack, bold } from "colorette";
 import terminalKitPackage from "terminal-kit";
-import alert from "alert";
+import { notify } from "node-notifier";
 import { example, rl } from ".";
 import path from "path";
 
@@ -64,6 +64,6 @@ export const pen = () => {
     process.exit();
   }, 10000);
   thePen;
-  alert("🚨TIME🚨");
+  notify("🚨TIME🚨");
   clearAll;
 };

--- a/src/rei.ts
+++ b/src/rei.ts
@@ -6,7 +6,7 @@ import {
   bgBlack,
   cyan,
 } from "colorette";
-import alert from "alert";
+import { notify } from "node-notifier";
 import terminalKitPackage from "terminal-kit";
 import { example, rl } from ".";
 import path from "path";
@@ -71,6 +71,6 @@ export const rei = () => {
     process.exit();
   }, 10000);
   blink;
-  alert("🚨TIME🚨");
+  notify("🚨TIME🚨");
   clearAll;
 };

--- a/src/seele.ts
+++ b/src/seele.ts
@@ -1,6 +1,6 @@
 import { red, yellow, bold } from "colorette";
 import terminalKitPackage from "terminal-kit";
-import alert from "alert";
+import { notify } from "node-notifier";
 import { example, rl } from ".";
 import path from "path";
 
@@ -42,6 +42,6 @@ export const seele = () => {
     process.exit();
   }, 10000);
   bakaRun;
-  alert("🚨TIME🚨");
+  notify("🚨TIME🚨");
   clearBaka;
 };

--- a/src/shinji.ts
+++ b/src/shinji.ts
@@ -1,6 +1,6 @@
 import { red, yellow, bold } from "colorette";
 import terminalKitPackage from "terminal-kit";
-import alert from "alert";
+import { notify } from "node-notifier";
 import { example, rl } from ".";
 import path from "path";
 
@@ -45,6 +45,6 @@ export const shinji = () => {
     process.exit();
   }, 10000);
   bakaRun;
-  alert("🚨TIME🚨");
+  notify("🚨TIME🚨");
   clearBaka;
 };

--- a/src/unit-03.ts
+++ b/src/unit-03.ts
@@ -1,6 +1,6 @@
 import { red, yellow, bold } from "colorette";
 import terminalKitPackage from "terminal-kit";
-import alert from "alert";
+import { notify } from "node-notifier";
 import { example, rl } from ".";
 import path from "path";
 
@@ -60,6 +60,6 @@ export const unit03 = () => {
     process.exit();
   }, 10000);
   walk;
-  alert("🚨TIME🚨");
+  notify("🚨TIME🚨");
   clearAll;
 };


### PR DESCRIPTION
closes #15 

Hi @JWW127,

I've made a small update that switches from using the "alert" package to "node-notifier." Could you please bump the version and push this change to npm? This way, your package won't be a dependent of the "alert" package anymore.

Cheers,
Patrick